### PR TITLE
[EC-411] Fix issue with `main` branch trigger

### DIFF
--- a/io-backend-projects/core/05_tlscert-prod-api-app-internal-io-pagopa-it.tf
+++ b/io-backend-projects/core/05_tlscert-prod-api-app-internal-io-pagopa-it.tf
@@ -83,7 +83,7 @@ module "tlscert-prod-api-app-internal-io-pagopa-it-cert_az" {
     start_minutes              = 10
     time_zone                  = "(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"
     branch_filter = {
-      include = ["master", "main"]
+      include = ["master"]
       exclude = []
     }
   }

--- a/io-backend-projects/core/05_tlscert-prod-api-app-io-pagopa-it.tf
+++ b/io-backend-projects/core/05_tlscert-prod-api-app-io-pagopa-it.tf
@@ -84,7 +84,7 @@ module "tlscert-prod-api-app-io-pagopa-it-cert_az" {
     start_minutes              = 20
     time_zone                  = "(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"
     branch_filter = {
-      include = ["master", "main"]
+      include = ["master"]
       exclude = []
     }
   }

--- a/io-backend-projects/core/05_tlscert-prod-api-gad-io-italia-it.tf
+++ b/io-backend-projects/core/05_tlscert-prod-api-gad-io-italia-it.tf
@@ -83,7 +83,7 @@ module "tlscert-prod-api-gad-io-italia-it-cert_az" {
     start_minutes              = 30
     time_zone                  = "(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"
     branch_filter = {
-      include = ["master", "main"]
+      include = ["master"]
       exclude = []
     }
   }

--- a/io-backend-projects/core/05_tlscert-prod-api-internal-io-italia-it.tf
+++ b/io-backend-projects/core/05_tlscert-prod-api-internal-io-italia-it.tf
@@ -83,7 +83,7 @@ module "tlscert-prod-api-internal-io-italia-it-cert_az" {
     start_minutes              = 40
     time_zone                  = "(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"
     branch_filter = {
-      include = ["master", "main"]
+      include = ["master"]
       exclude = []
     }
   }

--- a/io-backend-projects/core/05_tlscert-prod-api-io-italia-it.tf
+++ b/io-backend-projects/core/05_tlscert-prod-api-io-italia-it.tf
@@ -83,7 +83,7 @@ module "tlscert-prod-api-io-italia-it-cert_az" {
     start_minutes              = 50
     time_zone                  = "(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"
     branch_filter = {
-      include = ["master", "main"]
+      include = ["master"]
       exclude = []
     }
   }

--- a/io-backend-projects/core/05_tlscert-prod-api-io-pagopa-it.tf
+++ b/io-backend-projects/core/05_tlscert-prod-api-io-pagopa-it.tf
@@ -83,7 +83,7 @@ module "tlscert-prod-api-io-pagopa-it-cert_az" {
     start_minutes              = 0
     time_zone                  = "(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"
     branch_filter = {
-      include = ["master", "main"]
+      include = ["master"]
       exclude = []
     }
   }

--- a/io-backend-projects/core/05_tlscert-prod-api-mtls-io-pagopa-it.tf
+++ b/io-backend-projects/core/05_tlscert-prod-api-mtls-io-pagopa-it.tf
@@ -83,7 +83,7 @@ module "tlscert-prod-api-mtls-io-pagopa-it-cert_az" {
     start_minutes              = 10
     time_zone                  = "(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"
     branch_filter = {
-      include = ["master", "main"]
+      include = ["master"]
       exclude = []
     }
   }

--- a/io-backend-projects/core/05_tlscert-prod-app-backend-io-italia-it.tf
+++ b/io-backend-projects/core/05_tlscert-prod-app-backend-io-italia-it.tf
@@ -84,7 +84,7 @@ module "tlscert-prod-app-backend-io-italia-it-cert_az" {
     start_minutes              = 20
     time_zone                  = "(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"
     branch_filter = {
-      include = ["master", "main"]
+      include = ["master"]
       exclude = []
     }
   }

--- a/io-backend-projects/core/05_tlscert-prod-continua-io-pagopa-it.tf
+++ b/io-backend-projects/core/05_tlscert-prod-continua-io-pagopa-it.tf
@@ -84,7 +84,7 @@ module "tlscert-prod-continua-io-pagopa-it-cert_az" {
     start_minutes              = 30
     time_zone                  = "(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"
     branch_filter = {
-      include = ["master", "main"]
+      include = ["master"]
       exclude = []
     }
   }

--- a/io-backend-projects/core/05_tlscert-prod-developerportal-backend-io-italia-it.tf
+++ b/io-backend-projects/core/05_tlscert-prod-developerportal-backend-io-italia-it.tf
@@ -83,7 +83,7 @@ module "tlscert-prod-developerportal-backend-io-italia-it-cert_az" {
     start_minutes              = 40
     time_zone                  = "(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"
     branch_filter = {
-      include = ["master", "main"]
+      include = ["master"]
       exclude = []
     }
   }

--- a/io-backend-projects/core/05_tlscert-prod-firma-io-italia-it.tf
+++ b/io-backend-projects/core/05_tlscert-prod-firma-io-italia-it.tf
@@ -84,7 +84,7 @@ module "tlscert-prod-firma-io-italia-it-cert_az" {
     start_minutes              = 50
     time_zone                  = "(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"
     branch_filter = {
-      include = ["master", "main"]
+      include = ["master"]
       exclude = []
     }
   }

--- a/io-backend-projects/core/05_tlscert-prod-io-italia-it.tf
+++ b/io-backend-projects/core/05_tlscert-prod-io-italia-it.tf
@@ -84,7 +84,7 @@ module "tlscert-prod-io-italia-it-cert_az" {
     start_minutes              = 10
     time_zone                  = "(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"
     branch_filter = {
-      include = ["master", "main"]
+      include = ["master"]
       exclude = []
     }
   }

--- a/io-backend-projects/core/05_tlscert-prod-oauth-io-pagopa-it.tf
+++ b/io-backend-projects/core/05_tlscert-prod-oauth-io-pagopa-it.tf
@@ -84,7 +84,7 @@ module "tlscert-prod-oauth-io-pagopa-it-cert_az" {
     start_minutes              = 20
     time_zone                  = "(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"
     branch_filter = {
-      include = ["master", "main"]
+      include = ["master"]
       exclude = []
     }
   }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Remove `main` branch from branch filtering

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

For some reason, DevOps now puts in schedule all the branch included in the branch filtering configuration, despite it shouldn't and always did not. From doc:

> If `new-feature` is added to the branches list and this change is pushed to the `new-feature` branch, the YAML file is read, and since `new-feature` is now in the branches list, a scheduled build is added for the `new-feature` branch

Pipelines were adding both `master` and `main` as branch name filters to avoid issues in case of default branch rebranding in the common repository hosting the pipeline.

### Type of changes

- [ ] Add new pipeline
- [X] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
